### PR TITLE
Fix key view loop crash – COPPER-1351

### DIFF
--- a/CCNStatusItem/CCNStatusItemWindow.m
+++ b/CCNStatusItem/CCNStatusItemWindow.m
@@ -99,10 +99,6 @@
     [self.backgroundView addSubview:self.userContentView];
 }
 
-- (id)contentView {
-    return self.userContentView;
-}
-
 - (NSRect)frameRectForContentRect:(NSRect)contentRect {
     return NSMakeRect(NSMinX(contentRect), NSMinY(contentRect), NSWidth(contentRect), NSHeight(contentRect) + CCNDefaultArrowHeight);
 }


### PR DESCRIPTION
## Changes
* https://invisionapp.atlassian.net/browse/COPPER-1351
* Fix crash that occurs from overriding `contentView` getter on a NSWindow instance.
* Changes derived from https://github.com/sbooth/SFBPopovers/pull/9

## Testing

1. Run the example app
2. Open the menu bar popover
3. Press the tab key
4. Notice that no exception occurs (on the develop branch, an exception occurs due to overriding `contentView`).