### PR TITLE
CRAFT-2483 If isPinned is turned off, check before we close the tab

### DIFF
--- a/CCNStatusItem/CCNStatusItem.m
+++ b/CCNStatusItem/CCNStatusItem.m
@@ -456,9 +456,11 @@ static NSString *const CCNStatusItemWindowConfigurationPinnedPath = @"windowConf
             [self disableDragEventMonitor];
         }
         else {
-            [self dismissStatusItemWindow];
-            if (self.proximityDragDetectionEnabled) {
-                [self enableDragEventMonitor];
+            if (self.windowConfiguration.isPinned == NO && self.window.isKeyWindow == NO) {
+                [self dismissStatusItemWindow];
+                if (self.proximityDragDetectionEnabled) {
+                    [self enableDragEventMonitor];
+                }
             }
         }
     }


### PR DESCRIPTION
This PR will prevent the closing of the item window if isPinned is set to NO and the window is currently visible